### PR TITLE
Fix language switching and header watchers

### DIFF
--- a/components/header/Header.vue
+++ b/components/header/Header.vue
@@ -43,22 +43,12 @@ const handleDrawerClose = () => {
 }
 
 watch(
-    () => isAuthenticated,
-    (isAuth) => {
-      if (isAuth) {
-        showLoginModal.value = false
-      }
+  isAuthenticated,
+  (isAuth) => {
+    if (isAuth) {
+      showLoginModal.value = false
     }
-)
-
-
-watch(
-    () => isAuthenticated,
-    (isAuth) => {
-      if (isAuth) {
-        showLoginModal.value = false
-      }
-    }
+  }
 )
 
 

--- a/components/header/utils/NavigationActions.vue
+++ b/components/header/utils/NavigationActions.vue
@@ -8,6 +8,7 @@ const route = useRoute()
 
 const showLanguageMenu = ref(false)
 const flag = ref('🇫🇷')
+const loadingLocale = ref(false)
 
 // Initialize locale from localStorage on component mount
 onMounted(() => {
@@ -29,7 +30,9 @@ watch(() => route.path, () => {
 })
 
 async function changeLanguage(lo: 'fr' | 'en' | 'es', flagEmoji: string) {
+  loadingLocale.value = true
   await setLocale(lo)
+  loadingLocale.value = false
   showLanguageMenu.value = false
   flag.value = flagEmoji
 
@@ -45,6 +48,9 @@ function toggleLanguageMenu(value: boolean) {
 <template>
   <div class="relative">
     <LocationContextComponent @toggle-language-menu="toggleLanguageMenu" :flag="flag" />
+    <div v-if="loadingLocale" class="absolute right-0 -top-2">
+      <span class="loading loading-spinner loading-sm"></span>
+    </div>
     <LanguageComponent @change-language="changeLanguage" :show-language-menu="showLanguageMenu" />
   </div>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
       { code: 'fr', name: 'Français', file: 'fr.json' },
       { code: 'en', name: 'English', file: 'en.json' },
     ],
-    lazy: true,
+    lazy: false,
     langDir: 'locales',
     defaultLocale: 'fr',
     vueI18n: './i18n.config.ts'


### PR DESCRIPTION
## Summary
- fix duplicated `watch` in `Header.vue`
- add spinner while switching languages
- preload i18n locales so there is no delay on language switch

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560c372068832e979728cad9ab5ee5